### PR TITLE
feat/get-all-courses

### DIFF
--- a/backend/src/main/java/com/github/esgoet/backend/controller/CourseController.java
+++ b/backend/src/main/java/com/github/esgoet/backend/controller/CourseController.java
@@ -1,0 +1,23 @@
+package com.github.esgoet.backend.controller;
+
+import com.github.esgoet.backend.model.Course;
+import com.github.esgoet.backend.service.CourseService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/courses")
+@RequiredArgsConstructor
+public class CourseController {
+    private final CourseService courseService;
+
+    @GetMapping
+    public List<Course> getAllCourses() {
+        return courseService.getAllCourses();
+    }
+
+}

--- a/backend/src/main/java/com/github/esgoet/backend/model/Course.java
+++ b/backend/src/main/java/com/github/esgoet/backend/model/Course.java
@@ -1,0 +1,15 @@
+package com.github.esgoet.backend.model;
+
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.List;
+
+@Document("courses")
+public record Course(
+        String id,
+        String name,
+        String description,
+        List<String> students,
+        List<String> instructors
+) {
+}

--- a/backend/src/main/java/com/github/esgoet/backend/repository/CourseRepository.java
+++ b/backend/src/main/java/com/github/esgoet/backend/repository/CourseRepository.java
@@ -1,0 +1,9 @@
+package com.github.esgoet.backend.repository;
+
+import com.github.esgoet.backend.model.Course;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CourseRepository extends MongoRepository<Course, String> {
+}

--- a/backend/src/main/java/com/github/esgoet/backend/service/CourseService.java
+++ b/backend/src/main/java/com/github/esgoet/backend/service/CourseService.java
@@ -1,0 +1,18 @@
+package com.github.esgoet.backend.service;
+
+import com.github.esgoet.backend.model.Course;
+import com.github.esgoet.backend.repository.CourseRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CourseService {
+    private final CourseRepository courseRepository;
+
+    public List<Course> getAllCourses() {
+        return courseRepository.findAll();
+    }
+}

--- a/backend/src/test/java/com/github/esgoet/backend/controller/CourseControllerTest.java
+++ b/backend/src/test/java/com/github/esgoet/backend/controller/CourseControllerTest.java
@@ -1,0 +1,30 @@
+package com.github.esgoet.backend.controller;
+
+import com.github.esgoet.backend.repository.CourseRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class CourseControllerTest {
+    @Autowired
+    MockMvc mockMvc;
+    @Autowired
+    CourseRepository courseRepository;
+
+    @Test
+    void getAllCoursesTest() throws Exception {
+        //WHEN
+        mockMvc.perform(get("/api/courses"))
+                //THEN
+                .andExpect(status().isOk())
+                .andExpect(content().json("[]"));
+    }
+}

--- a/backend/src/test/java/com/github/esgoet/backend/service/CourseServiceTest.java
+++ b/backend/src/test/java/com/github/esgoet/backend/service/CourseServiceTest.java
@@ -1,0 +1,41 @@
+package com.github.esgoet.backend.service;
+
+import com.github.esgoet.backend.model.Course;
+import com.github.esgoet.backend.repository.CourseRepository;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class CourseServiceTest {
+    private final CourseRepository courseRepository = mock(CourseRepository.class);
+    private final CourseService courseService = new CourseService(courseRepository);
+
+    @Test
+    void getAllCoursesTest_whenEmptyDb_thenReturnEmptyList() {
+        //GIVEN
+        when(courseRepository.findAll()).thenReturn(List.of());
+        //WHEN
+        List<Course> actual = courseService.getAllCourses();
+        //THEN
+        List<Course> expected = new ArrayList<>();
+        verify(courseRepository).findAll();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void getAllCoursesTest_whenCoursesExist_thenReturnListOfCourses() {
+        //GIVEN
+        List<Course> courses = List.of(new Course("1", "Math 101", "This is Math 101", List.of("1","2"),  List.of("1","2")));
+        when(courseRepository.findAll()).thenReturn(courses);
+        //WHEN
+        List<Course> actual = courseService.getAllCourses();
+        //THEN
+        List<Course> expected = List.of(new Course("1", "Math 101", "This is Math 101", List.of("1","2"),  List.of("1","2")));
+        verify(courseRepository).findAll();
+        assertEquals(expected, actual);
+    }
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "axios": "^1.7.5",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -1618,6 +1619,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.5.tgz",
+      "integrity": "sha512-fZu86yCo+svH3uqJ/yTdQ0QHpQu5oL+/QE+QPSv6BZSkDAoky9vytxp7u5qk83OJFS3kEBcesWni9WTZAv3tSw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1745,6 +1763,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1805,6 +1835,15 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -2276,6 +2315,40 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2611,6 +2684,27 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -2815,6 +2909,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "axios": "^1.7.5",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,9 +1,32 @@
 import './App.css'
+import {useEffect, useState} from "react";
+import {Course} from "./types/types.ts";
+import axios from 'axios';
 
 export default function App() {
+  const [courses, setCourses] = useState<Course[]>([])
+
+  const fetchCourses = () => {
+    axios.get("/api/courses")
+        .then((response) => setCourses(response.data))
+        .catch((error) => console.log(error))
+  }
+
+  useEffect(()=>{
+    fetchCourses();
+  }, [])
 
   return (
     <>
+      <section>
+        <h2>Courses</h2>
+        {courses.map((course)=> (
+            <article>
+              <h3>{course.name}</h3>
+              <p>{course.description}</p>
+            </article>
+        ))}
+      </section>
     </>
   )
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import './App.css'
 import {useEffect, useState} from "react";
 import {Course} from "./types/types.ts";
 import axios from 'axios';
+import CourseList from "./components/CourseList.tsx";
 
 export default function App() {
   const [courses, setCourses] = useState<Course[]>([])
@@ -18,15 +19,8 @@ export default function App() {
 
   return (
     <>
-      <section>
-        <h2>Courses</h2>
-        {courses.map((course)=> (
-            <article>
-              <h3>{course.name}</h3>
-              <p>{course.description}</p>
-            </article>
-        ))}
-      </section>
+      <h1>Learning Management System</h1>
+      <CourseList courses={courses}/>
     </>
   )
 }

--- a/frontend/src/components/CourseList.tsx
+++ b/frontend/src/components/CourseList.tsx
@@ -1,0 +1,19 @@
+import {Course} from "../types/types.ts";
+
+type CourseListProps = {
+    courses: Course[]
+}
+
+export default function CourseList({courses}: CourseListProps) {
+    return (
+        <section>
+            <h2>Courses</h2>
+            {courses.map((course) => (
+                <article>
+                    <h3>{course.name}</h3>
+                    <p>{course.description}</p>
+                </article>
+            ))}
+        </section>
+    )
+}

--- a/frontend/src/types/types.ts
+++ b/frontend/src/types/types.ts
@@ -1,0 +1,7 @@
+export type Course = {
+    id: string,
+    name: string,
+    description: string,
+    students: string[],
+    instructors: string[]
+}


### PR DESCRIPTION
Goal: load all courses saved in database to frontend through api

Backend:
- Created Course model with id, name, description, students and instructors as properties
- Added getAllCourses endpoint in CourseController, implement with CourseService and CourseRepository
- Implemented Unit-Tests for CourseService (with Mockito) and Integration-Tests for CourseController (with MockMvc)

Frontend:
- created the Course type equivalent to backend
- made a courses useState variable to save the loaded courses
- created a fetchCourses() function with an axios call to the backend, which calls setCourses to save the response data
- called fetchCourses within a useEffect to load the data when loading the component
- created a Courses Component, receiving courses as props, to display the loaded courses with the map() function
