### PR TITLE
Feat/get-course-by-id

### DIFF
--- a/backend/src/main/java/com/github/esgoet/backend/controller/CourseController.java
+++ b/backend/src/main/java/com/github/esgoet/backend/controller/CourseController.java
@@ -4,6 +4,7 @@ import com.github.esgoet.backend.model.Course;
 import com.github.esgoet.backend.service.CourseService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -18,6 +19,11 @@ public class CourseController {
     @GetMapping
     public List<Course> getAllCourses() {
         return courseService.getAllCourses();
+    }
+
+    @GetMapping("/{id}")
+    public Course getCourseById(@PathVariable String id) {
+        return courseService.getCourseById(id);
     }
 
 }

--- a/backend/src/main/java/com/github/esgoet/backend/exception/CourseNotFoundException.java
+++ b/backend/src/main/java/com/github/esgoet/backend/exception/CourseNotFoundException.java
@@ -1,0 +1,7 @@
+package com.github.esgoet.backend.exception;
+
+public class CourseNotFoundException extends RuntimeException {
+    public CourseNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/github/esgoet/backend/exception/CustomErrorMessage.java
+++ b/backend/src/main/java/com/github/esgoet/backend/exception/CustomErrorMessage.java
@@ -1,0 +1,10 @@
+package com.github.esgoet.backend.exception;
+
+import java.time.LocalDateTime;
+
+public record CustomErrorMessage(
+        String message,
+        LocalDateTime timestamp,
+        int statusCode
+) {
+}

--- a/backend/src/main/java/com/github/esgoet/backend/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/github/esgoet/backend/exception/GlobalExceptionHandler.java
@@ -1,0 +1,21 @@
+package com.github.esgoet.backend.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.LocalDateTime;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(CourseNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public CustomErrorMessage handleCourseNotFoundException(CourseNotFoundException e) {
+        return new CustomErrorMessage(
+                e.getMessage(),
+                LocalDateTime.now(),
+                HttpStatus.NOT_FOUND.value()
+        );
+    }
+}

--- a/backend/src/main/java/com/github/esgoet/backend/model/Course.java
+++ b/backend/src/main/java/com/github/esgoet/backend/model/Course.java
@@ -7,7 +7,7 @@ import java.util.List;
 @Document("courses")
 public record Course(
         String id,
-        String name,
+        String title,
         String description,
         List<String> students,
         List<String> instructors

--- a/backend/src/main/java/com/github/esgoet/backend/service/CourseService.java
+++ b/backend/src/main/java/com/github/esgoet/backend/service/CourseService.java
@@ -1,5 +1,6 @@
 package com.github.esgoet.backend.service;
 
+import com.github.esgoet.backend.exception.CourseNotFoundException;
 import com.github.esgoet.backend.model.Course;
 import com.github.esgoet.backend.repository.CourseRepository;
 import lombok.RequiredArgsConstructor;
@@ -14,5 +15,9 @@ public class CourseService {
 
     public List<Course> getAllCourses() {
         return courseRepository.findAll();
+    }
+
+    public Course getCourseById(String id) {
+        return courseRepository.findById(id).orElseThrow(()-> new CourseNotFoundException("No course found with id: " + id));
     }
 }

--- a/backend/src/test/java/com/github/esgoet/backend/controller/CourseControllerTest.java
+++ b/backend/src/test/java/com/github/esgoet/backend/controller/CourseControllerTest.java
@@ -43,7 +43,7 @@ class CourseControllerTest {
                 .andExpect(content().json("""
                     {
                       "id": "1",
-                      "name": "Math 101",
+                      "title": "Math 101",
                       "description": "This is Math 101",
                       "students": ["1","2"],
                       "instructors": ["1","2"]

--- a/backend/src/test/java/com/github/esgoet/backend/controller/CourseControllerTest.java
+++ b/backend/src/test/java/com/github/esgoet/backend/controller/CourseControllerTest.java
@@ -1,15 +1,18 @@
 package com.github.esgoet.backend.controller;
 
+import com.github.esgoet.backend.model.Course;
 import com.github.esgoet.backend.repository.CourseRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.List;
+
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -26,5 +29,39 @@ class CourseControllerTest {
                 //THEN
                 .andExpect(status().isOk())
                 .andExpect(content().json("[]"));
+    }
+
+    @Test
+    @DirtiesContext
+    void getCourseByIdTest_whenCourseExists() throws Exception {
+        //GIVEN
+        courseRepository.save(new Course("1", "Math 101", "This is Math 101", List.of("1","2"),  List.of("1","2")));
+        //WHEN
+        mockMvc.perform(get("/api/courses/1"))
+                //THEN
+                .andExpect(status().isOk())
+                .andExpect(content().json("""
+                    {
+                      "id": "1",
+                      "name": "Math 101",
+                      "description": "This is Math 101",
+                      "students": ["1","2"],
+                      "instructors": ["1","2"]
+                    }
+                    """));
+    }
+
+    @Test
+    void getCourseByIdTest_whenCourseDoesNotExist() throws Exception {
+        //WHEN
+        mockMvc.perform(get("/api/courses/1"))
+                .andExpect(status().isNotFound())
+                .andExpect(content().json("""
+                    {
+                      "message": "No course found with id: 1",
+                      "statusCode": 404
+                    }
+                    """))
+                .andExpect(jsonPath("$.timestamp").exists());
     }
 }

--- a/backend/src/test/java/com/github/esgoet/backend/service/CourseServiceTest.java
+++ b/backend/src/test/java/com/github/esgoet/backend/service/CourseServiceTest.java
@@ -1,11 +1,13 @@
 package com.github.esgoet.backend.service;
 
+import com.github.esgoet.backend.exception.CourseNotFoundException;
 import com.github.esgoet.backend.model.Course;
 import com.github.esgoet.backend.repository.CourseRepository;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -37,5 +39,29 @@ class CourseServiceTest {
         List<Course> expected = List.of(new Course("1", "Math 101", "This is Math 101", List.of("1","2"),  List.of("1","2")));
         verify(courseRepository).findAll();
         assertEquals(expected, actual);
+    }
+
+    @Test
+    void getCourseByIdTest_whenCourseExists_thenReturnCourse() {
+        //GIVEN
+        Course course = new Course("1", "Math 101", "This is Math 101", List.of("1","2"),  List.of("1","2"));
+        when(courseRepository.findById("1")).thenReturn(Optional.of(course));
+        //WHEN
+        Course actual = courseService.getCourseById("1");
+        //THEN
+        Course expected =  new Course("1", "Math 101", "This is Math 101", List.of("1","2"),  List.of("1","2"));
+        verify(courseRepository).findById("1");
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void getCourseByIdTest_whenCourseDoesNotExist_thenThrowException() {
+        //GIVEN
+        when(courseRepository.findById("1")).thenReturn(Optional.empty());
+        //THEN
+        assertThrows(CourseNotFoundException.class,
+                //WHEN
+                () -> courseService.getCourseById("1"));
+        verify(courseRepository).findById("1");
     }
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "axios": "^1.7.5",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "react-router-dom": "^6.26.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.9.0",
@@ -971,6 +972,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.19.1.tgz",
+      "integrity": "sha512-S45oynt/WH19bHbIXjtli6QmwNYvaz+vtnubvNpNDvUOoA/OWh6j1OikIP3G+v5GHdxyC6EXoChG3HgYGEUfcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -2980,6 +2990,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.26.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.26.1.tgz",
+      "integrity": "sha512-kIwJveZNwp7teQRI5QmwWo39A5bXRyqpH0COKKmPnyD2vBvDwgFXSqDUYtt1h+FEyfnE8eXr7oe0MxRzVwCcvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.19.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.26.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.26.1.tgz",
+      "integrity": "sha512-veut7m41S1fLql4pLhxeSW3jlqs+4MtjRLj0xvuCEXsxusJCbs6I8yn9BxzzDX2XDgafrccY6hwjmd/bL54tFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.19.1",
+        "react-router": "6.26.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/resolve-from": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "axios": "^1.7.5",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.26.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,7 +22,7 @@ export default function App() {
         <h2>Courses</h2>
         {courses.map((course)=> (
             <article>
-              <h3>{course.name}</h3>
+              <h3>{course.title}</h3>
               <p>{course.description}</p>
             </article>
         ))}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,8 @@ import {useEffect, useState} from "react";
 import {Course} from "./types/types.ts";
 import axios from 'axios';
 import CourseList from "./components/CourseList.tsx";
+import {Route, Routes} from "react-router-dom";
+import CoursePage from "./components/CoursePage.tsx";
 
 export default function App() {
   const [courses, setCourses] = useState<Course[]>([])
@@ -20,7 +22,11 @@ export default function App() {
   return (
     <>
       <h1>Learning Management System</h1>
-      <CourseList courses={courses}/>
+      <Routes>
+        <Route path={"/"} element={ <CourseList courses={courses}/>}/>
+        <Route path={"/course/:id"} element={<CoursePage/>}/>
+      </Routes>
+
     </>
   )
 }

--- a/frontend/src/components/CourseList.tsx
+++ b/frontend/src/components/CourseList.tsx
@@ -1,4 +1,5 @@
 import {Course} from "../types/types.ts";
+import {Link} from "react-router-dom";
 
 type CourseListProps = {
     courses: Course[]
@@ -8,12 +9,14 @@ export default function CourseList({courses}: CourseListProps) {
     return (
         <section>
             <h2>Courses</h2>
-            {courses.map((course) => (
-                <article>
-                    <h3>{course.name}</h3>
-                    <p>{course.description}</p>
-                </article>
-            ))}
+            <ul>
+                {courses.map((course) => (
+                    <li key={course.id}>
+                        <h3>{course.title}</h3>
+                        <Link to={`/course/${course.id}`}>Details</Link>
+                    </li>
+                ))}
+            </ul>
         </section>
     )
 }

--- a/frontend/src/components/CoursePage.tsx
+++ b/frontend/src/components/CoursePage.tsx
@@ -1,0 +1,37 @@
+import {Link, useParams} from "react-router-dom";
+import {Course} from "../types/types.ts";
+import {useEffect, useState} from "react";
+import axios from "axios";
+
+export default function CoursePage() {
+    const params = useParams();
+    const id : string | undefined = params.id;
+
+    const [course, setCourse] = useState<Course | undefined>();
+
+    const fetchCourse = () => {
+        axios.get(`/api/courses/${id}`)
+            .then((response) => setCourse(response.data))
+            .catch((error) => {
+                console.log(error.response.data);
+                setCourse(undefined);
+            })
+    }
+
+    useEffect(() =>{
+        fetchCourse()
+    },[])
+
+    return (
+        <>
+            {course ?
+            <>
+                <h2>{course.title}</h2>
+                <p>{course.description}</p>
+            </>
+            :
+            <p>No course found.</p>}
+            <Link to={"/"}>Back</Link>
+        </>
+    )
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
+import { BrowserRouter } from 'react-router-dom'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+      <BrowserRouter>
+          <App />
+      </BrowserRouter>
   </StrictMode>,
 )

--- a/frontend/src/types/types.ts
+++ b/frontend/src/types/types.ts
@@ -1,6 +1,6 @@
 export type Course = {
     id: string,
-    name: string,
+    title: string,
     description: string,
     students: string[],
     instructors: string[]


### PR DESCRIPTION
Goal: load details of one course on a separate page in frontend through api

Backend:
- Added getCourseById endpoint in CourseController, implemented with CourseService and CourseRepository
- Created new Exception Type and GlobalExceptionHandler in case of no course having the id
- Implemented Unit-Tests for getCourseById in CourseService (with Mockito) and Integration-Tests for  getCourseById in CourseController (with MockMvc)

Frontend:
- installed React Router to use in App.tsx
- linked from CourseList items to the details page
- made CoursePage component, that gets the id from the url 
- created a fetchCourse() function with an axios call to the backend, which calls setCourse to save the response data
- called fetchCourse within a useEffect to load the data when loading the component
- displayed Data

Refactoring:
- Changed Course property name to title to be more appropriate
- CourseList uses now an actual list
