### PR TITLE
feat/add-course-context

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -205,15 +205,15 @@ export default function App() {
                                 <Route path={"/browse"} element={<BrowsePage courses={courses} deleteCourse={deleteCourse} updateUser={updateUser} updateCourse={updateCourse}/>}/>
                                 <Route path={"/account"} element={<UserAccountPage updateUser={updateUser} deleteUser={deleteUser}/>}/>
                                 <Route path={"/course/:courseId"} element={<CourseDetailsPage updateCourse={updateCourse} course={currentCourse} fetchCourse={fetchCourse} deleteCourse={deleteCourse} students={students} instructors={instructors} updateUser={updateUser}/>}>
-                                    <Route path={"participants"} element={<ParticipantOverview currentStudents={currentCourse?.students || []} currentInstructors={currentCourse?.instructors || []} students={students} instructors={instructors} updateCourse={updateCourse}/>}/>
-                                    <Route path={"lessons"} element={<LessonOverview lessons={currentCourse?.lessons} updateCourse={updateCourse}/>}/>
-                                    <Route path={"lessons/:lessonId"} element={<LessonPage lessons={currentCourse?.lessons} updateCourse={updateCourse}/>}/>
-                                    <Route path={"assignments"} element={<AssignmentOverview assignments={currentCourse?.assignments} updateCourse={updateCourse}/>}/>
-                                    <Route path={"assignments/:assignmentId"} element={<AssignmentPage assignments={currentCourse?.assignments} updateCourse={updateCourse}/>}/>
-                                    <Route path={"assignments/:assignmentId/submission/:submissionId"} element={<SubmissionPage assignments={currentCourse?.assignments}/>}/>
+                                    <Route path={"participants"} element={<ParticipantOverview students={students} instructors={instructors} updateCourse={updateCourse}/>}/>
+                                    <Route path={"lessons"} element={<LessonOverview updateCourse={updateCourse}/>}/>
+                                    <Route path={"lessons/:lessonId"} element={<LessonPage updateCourse={updateCourse}/>}/>
+                                    <Route path={"assignments"} element={<AssignmentOverview updateCourse={updateCourse}/>}/>
+                                    <Route path={"assignments/:assignmentId"} element={<AssignmentPage updateCourse={updateCourse}/>}/>
+                                    <Route path={"assignments/:assignmentId/submission/:submissionId"} element={<SubmissionPage/>}/>
                                     <Route element={<ProtectedInstructorRoutes />}>
-                                        <Route path={"lessons/create"} element={<LessonCreator updateCourse={updateCourse} lessons={currentCourse?.lessons}/>}/>
-                                        <Route path={"assignments/create"} element={<AssignmentCreator assignments={currentCourse?.assignments} updateCourse={updateCourse} />}/>
+                                        <Route path={"lessons/create"} element={<LessonCreator updateCourse={updateCourse}/>}/>
+                                        <Route path={"assignments/create"} element={<AssignmentCreator updateCourse={updateCourse} />}/>
                                     </Route>
                                 </Route>
                                 <Route element={<ProtectedInstructorRoutes/>}>

--- a/frontend/src/hooks/useCourse.ts
+++ b/frontend/src/hooks/useCourse.ts
@@ -1,0 +1,11 @@
+
+import {useOutletContext} from "react-router-dom";
+import {Course} from "../types/courseTypes.ts";
+
+export type CourseContextType = {
+    course: Course | undefined;
+}
+
+export const useCourse = () => {
+    return useOutletContext<CourseContextType>();
+};

--- a/frontend/src/pages/CourseDetails/Assignment/AssignmentCreator.tsx
+++ b/frontend/src/pages/CourseDetails/Assignment/AssignmentCreator.tsx
@@ -1,15 +1,16 @@
-import {Assignment, AssignmentDto} from "../../../types/courseTypes.ts";
+import { AssignmentDto} from "../../../types/courseTypes.ts";
 import {ChangeEvent, FormEvent, useState} from "react";
 import {Link, useNavigate} from "react-router-dom";
 import {convertToAssignmentDtoList} from "../../../utils/convertToAssignmentDto.ts";
 import {Button, Grid2, TextField} from "@mui/material";
+import {useCourse} from "../../../hooks/useCourse.ts";
 
 type AssignmentCreatorProps = {
-    updateCourse: (updatedProperty: string, updatedValue: AssignmentDto[]) => void,
-    assignments: Assignment[] | undefined
+    updateCourse: (updatedProperty: string, updatedValue: AssignmentDto[]) => void
 }
 
-export default function AssignmentCreator({assignments, updateCourse}: Readonly<AssignmentCreatorProps>) {
+export default function AssignmentCreator({ updateCourse}: Readonly<AssignmentCreatorProps>) {
+    const {course} = useCourse();
     const [assignment, setAssignment] = useState<AssignmentDto>({
         id: "",
         title: "",
@@ -25,7 +26,7 @@ export default function AssignmentCreator({assignments, updateCourse}: Readonly<
     }
     const handleSubmit = (e : FormEvent<HTMLFormElement>) => {
         e.preventDefault();
-        if (assignments) updateCourse("assignments", [assignment,...convertToAssignmentDtoList(assignments)])
+        if (course) updateCourse("assignments", [assignment,...convertToAssignmentDtoList(course.assignments)])
         navigate("..",{ relative: "path" });
     }
 

--- a/frontend/src/pages/CourseDetails/Assignment/AssignmentOverview.tsx
+++ b/frontend/src/pages/CourseDetails/Assignment/AssignmentOverview.tsx
@@ -1,24 +1,25 @@
-import {Assignment, AssignmentDto} from "../../../types/courseTypes.ts";
+import {AssignmentDto} from "../../../types/courseTypes.ts";
 import {Link} from "react-router-dom";
 import {convertToAssignmentDtoList} from "../../../utils/convertToAssignmentDto.ts";
 import {useAuth} from "../../../hooks/useAuth.ts";
-import {Button, Divider, List, ListItem, ListItemButton, ListItemIcon, ListItemText} from "@mui/material";
+import {Button, List, ListItem, ListItemButton, ListItemIcon, ListItemText} from "@mui/material";
 import AddIcon from '@mui/icons-material/Add';
 import PendingActionsIcon from '@mui/icons-material/PendingActions';
 import ConfirmedDeleteIconButton from "../../../components/Shared/ConfirmedDeleteIconButton.tsx";
+import {useCourse} from "../../../hooks/useCourse.ts";
 
 type AssignmentOverviewProps = {
-    assignments: Assignment[] | undefined,
     updateCourse: (updatedProperty: string, updatedValue: AssignmentDto[]) => void;
 }
 
-export default function AssignmentOverview({assignments, updateCourse}: Readonly<AssignmentOverviewProps>) {
+export default function AssignmentOverview({updateCourse}: Readonly<AssignmentOverviewProps>) {
     const {isInstructor} = useAuth();
+    const {course} = useCourse();
 
     const deleteAssignment = (assignmentId: string) => {
-        if (assignments) {
+        if (course) {
             updateCourse("assignments",
-                convertToAssignmentDtoList(assignments.filter(assignment => assignment.id !== assignmentId)))
+                convertToAssignmentDtoList(course.assignments.filter(assignment => assignment.id !== assignmentId)))
         }
     }
 
@@ -33,27 +34,25 @@ export default function AssignmentOverview({assignments, updateCourse}: Readonly
                     variant={"outlined"}
                 >Create</Button>}
             <List>
-                {assignments?.filter(assignment => isInstructor ? assignment : assignment.whenPublic.valueOf() < Date.now()).toSorted((a, b) => a?.whenPublic.getTime() - b?.whenPublic.getTime()).map(assignment => (
-                    <>
-                        <ListItem
-                            key={`assignment-${assignment.id}`}
-                            secondaryAction={isInstructor &&
-                                <ConfirmedDeleteIconButton toConfirmId={assignment.id} toConfirmName={assignment.title} toConfirmFunction={deleteAssignment}/>}
-                            disablePadding
+                {course?.assignments.filter(assignment => isInstructor ? assignment : assignment.whenPublic.valueOf() < Date.now()).toSorted((a, b) => a?.whenPublic.getTime() - b?.whenPublic.getTime()).map(assignment => (
+                    <ListItem
+                        key={`assignment-${assignment.id}`}
+                        secondaryAction={isInstructor &&
+                            <ConfirmedDeleteIconButton toConfirmId={assignment.id} toConfirmName={assignment.title} toConfirmFunction={deleteAssignment}/>}
+                        disablePadding
+                        divider
+                    >
+                        <ListItemButton
+                            component={Link}
+                            to={`${assignment.id}`}
                         >
-                            <ListItemButton
-                                component={Link}
-                                to={`${assignment.id}`}
-                            >
-                                <ListItemText primary={assignment.title} secondary={assignment.whenPublic.valueOf() > Date.now() && "Unpublished"}/>
-                                <ListItemIcon sx={{display: 'flex', justifyContent: 'flex-end', pr: '5px'}}>
-                                    <PendingActionsIcon/>
-                                </ListItemIcon>
-                                <ListItemText primary={`${assignment.deadline.toDateString()}`} secondary={assignment.deadline.toLocaleTimeString()}/>
-                            </ListItemButton>
-                        </ListItem>
-                        <Divider/>
-                    </>
+                            <ListItemText primary={assignment.title} secondary={assignment.whenPublic.valueOf() > Date.now() && "Unpublished"}/>
+                            <ListItemIcon sx={{display: 'flex', justifyContent: 'flex-end', pr: '5px'}}>
+                                <PendingActionsIcon/>
+                            </ListItemIcon>
+                            <ListItemText primary={`${assignment.deadline.toDateString()}`} secondary={assignment.deadline.toLocaleTimeString()}/>
+                        </ListItemButton>
+                    </ListItem>
                 ))}
             </List>
         </>

--- a/frontend/src/pages/CourseDetails/Assignment/AssignmentPage.tsx
+++ b/frontend/src/pages/CourseDetails/Assignment/AssignmentPage.tsx
@@ -5,12 +5,12 @@ import {convertToAssignmentDto, convertToAssignmentDtoList} from "../../../utils
 import EditableTextDetail from "../../../components/Shared/EditableTextDetail.tsx";
 import { useAuth } from "../../../hooks/useAuth.ts";
 import {Button, List, ListItem, ListItemButton, ListItemText} from "@mui/material";
+import {useCourse} from "../../../hooks/useCourse.ts";
 
 type AssignmentPageProps = {
-    assignments: Assignment[] | undefined,
     updateCourse: (updatedProperty: string, updatedValue: AssignmentDto[]) => void
 }
-export default function AssignmentPage({assignments, updateCourse}: Readonly<AssignmentPageProps>) {
+export default function AssignmentPage({updateCourse}: Readonly<AssignmentPageProps>) {
     const [assignment, setAssignment] = useState<AssignmentDto|undefined>();
     const {assignmentId} = useParams();
     const [submission, setSubmission] = useState<SubmissionDto>({
@@ -19,20 +19,21 @@ export default function AssignmentPage({assignments, updateCourse}: Readonly<Ass
         content: "",
         timestamp: ""
     });
+    const {course} = useCourse();
     const {user, isInstructor} = useAuth();
 
     useEffect(()=> {
-        if (assignments) {
-            const currentAssignment : Assignment | undefined = assignments.find(assignment => assignment.id === assignmentId);
+        if (course) {
+            const currentAssignment : Assignment | undefined = course.assignments.find(assignment => assignment.id === assignmentId);
             if (currentAssignment) setAssignment(convertToAssignmentDto(currentAssignment))
         }
-    },[assignments, assignmentId])
+    },[course, assignmentId])
 
     const handleUpdate = (updatedProperty: string, updatedValue: string | SubmissionDto[]) => {
-        if (assignment && assignments) {
+        if (assignment && course) {
             const updatedAssignment = {...assignment,[updatedProperty]: updatedValue};
             setAssignment(updatedAssignment);
-            updateCourse("assignments", convertToAssignmentDtoList(assignments)
+            updateCourse("assignments", convertToAssignmentDtoList(course.assignments)
                 .map(assignment => assignment.id === assignmentId ? updatedAssignment : assignment));
         }
     }

--- a/frontend/src/pages/CourseDetails/Assignment/SubmissionPage.tsx
+++ b/frontend/src/pages/CourseDetails/Assignment/SubmissionPage.tsx
@@ -3,24 +3,22 @@ import {Assignment, SubmissionDto} from "../../../types/courseTypes.ts";
 import {useEffect, useState} from "react";
 import {Button, Grid2, Typography} from "@mui/material";
 import {formatDate} from "../../../utils/formatDate.ts";
+import {useCourse} from "../../../hooks/useCourse.ts";
 
-type SubmissionPageProps = {
-    assignments: Assignment[] | undefined
-}
-
-export default function SubmissionPage({assignments}: Readonly<SubmissionPageProps>) {
+export default function SubmissionPage() {
     const {submissionId, assignmentId} = useParams();
+    const {course} = useCourse();
     const [submission, setSubmission] = useState<SubmissionDto | undefined>();
 
     useEffect(()=> {
-        if (assignments) {
-            const currentAssignment : Assignment | undefined = assignments.find(assignment => assignment.id === assignmentId);
+        if (course) {
+            const currentAssignment : Assignment | undefined = course.assignments.find(assignment => assignment.id === assignmentId);
             if (currentAssignment) {
                 const currentSubmission = currentAssignment.submissions.find(submission => submission.id === submissionId)
                 if (currentSubmission) setSubmission({...currentSubmission, timestamp: currentSubmission.timestamp.toString()})
             }
         }
-    },[assignments, assignmentId, submissionId]);
+    },[course, assignmentId, submissionId]);
 
     return (
         <>

--- a/frontend/src/pages/CourseDetails/CourseDetailsPage.css
+++ b/frontend/src/pages/CourseDetails/CourseDetailsPage.css
@@ -1,6 +1,0 @@
-.course-page {
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-
-}

--- a/frontend/src/pages/CourseDetails/CourseDetailsPage.tsx
+++ b/frontend/src/pages/CourseDetails/CourseDetailsPage.tsx
@@ -12,6 +12,7 @@ import {
 } from "@mui/material";
 import CourseTabs from "../../components/Course/CourseTabs.tsx";
 import CourseTabsMobile from "../../components/Course/CourseTabsMobile.tsx";
+import {CourseContextType} from "../../hooks/useCourse.ts";
 
 type CoursePageProps = {
     updateCourse: (updatedProperty: string, updatedValue: string | string[]) => void,
@@ -73,7 +74,7 @@ export default function CourseDetailsPage({updateCourse, course, fetchCourse, de
                     </Paper>
                     {isMobile ? <CourseTabsMobile/> :
                     <CourseTabs/>}
-                    <Outlet/>
+                    <Outlet context={{course} satisfies CourseContextType}/>
                 </Container>
             :
             <p>No course found.</p>

--- a/frontend/src/pages/CourseDetails/CourseDetailsPage.tsx
+++ b/frontend/src/pages/CourseDetails/CourseDetailsPage.tsx
@@ -6,11 +6,10 @@ import {Instructor, Student} from "../../types/userTypes.ts";
 import {useAuth} from "../../hooks/useAuth.ts";
 import CourseActions from "../../components/Course/CourseActions.tsx";
 import {
-    Breadcrumbs,
+    Breadcrumbs, Container,
     Grid2, ListItem, ListItemText, Paper,
     Typography, useMediaQuery, useTheme
 } from "@mui/material";
-import "./CourseDetailsPage.css";
 import CourseTabs from "../../components/Course/CourseTabs.tsx";
 import CourseTabsMobile from "../../components/Course/CourseTabsMobile.tsx";
 
@@ -38,7 +37,7 @@ export default function CourseDetailsPage({updateCourse, course, fetchCourse, de
     return (
         <>
         {course ?
-                <div className={"course-page"}>
+                <Container>
                     <Breadcrumbs aria-label={"breadcrumb"}>
                         <Link to={"/"}>Dashboard</Link>
                         <Typography>{course?.title}</Typography>
@@ -75,7 +74,7 @@ export default function CourseDetailsPage({updateCourse, course, fetchCourse, de
                     {isMobile ? <CourseTabsMobile/> :
                     <CourseTabs/>}
                     <Outlet/>
-                </div>
+                </Container>
             :
             <p>No course found.</p>
         }

--- a/frontend/src/pages/CourseDetails/Lesson/LessonCreator.tsx
+++ b/frontend/src/pages/CourseDetails/Lesson/LessonCreator.tsx
@@ -1,15 +1,16 @@
-import {Lesson, LessonDto} from "../../../types/courseTypes.ts";
+import {LessonDto} from "../../../types/courseTypes.ts";
 import {ChangeEvent, FormEvent, useState} from "react";
 import {Link, useNavigate} from "react-router-dom";
 import {convertToLessonDtoList} from "../../../utils/convertToLessonDto.ts";
 import {Button, Grid2, TextField} from "@mui/material";
+import {useCourse} from "../../../hooks/useCourse.ts";
 
 type LessonCreatorProps = {
-    updateCourse: (updatedProperty: string, updatedValue: LessonDto[]) => void,
-    lessons: Lesson[] | undefined
+    updateCourse: (updatedProperty: string, updatedValue: LessonDto[]) => void
 }
 
-export default function LessonCreator({updateCourse, lessons}:Readonly<LessonCreatorProps>) {
+export default function LessonCreator({updateCourse}:Readonly<LessonCreatorProps>) {
+    const {course} = useCourse();
     const [lesson, setLesson] = useState<LessonDto>({
         id:"",
         title:"",
@@ -23,7 +24,7 @@ export default function LessonCreator({updateCourse, lessons}:Readonly<LessonCre
     }
     const handleSubmit = (e : FormEvent<HTMLFormElement>) => {
         e.preventDefault();
-        if (lessons) updateCourse("lessons", [lesson,...convertToLessonDtoList(lessons)])
+        if (course) updateCourse("lessons", [lesson,...convertToLessonDtoList(course.lessons)])
         navigate("..",{ relative: "path" });
     }
     

--- a/frontend/src/pages/CourseDetails/Lesson/LessonOverview.tsx
+++ b/frontend/src/pages/CourseDetails/Lesson/LessonOverview.tsx
@@ -1,23 +1,24 @@
-import {Lesson, LessonDto} from "../../../types/courseTypes.ts";
+import {LessonDto} from "../../../types/courseTypes.ts";
 import {Link} from "react-router-dom";
 import { convertToLessonDtoList} from "../../../utils/convertToLessonDto.ts";
 import {useAuth} from "../../../hooks/useAuth.ts";
-import {Button, Divider, List, ListItem, ListItemButton, ListItemText} from "@mui/material";
+import {Button, List, ListItem, ListItemButton, ListItemText} from "@mui/material";
 import AddIcon from "@mui/icons-material/Add";
 import ConfirmedDeleteIconButton from "../../../components/Shared/ConfirmedDeleteIconButton.tsx";
+import {useCourse} from "../../../hooks/useCourse.ts";
 
 
 type LessonOverviewProps = {
-    lessons: Lesson[] | undefined,
     updateCourse: (updatedProperty: string, updatedValue: LessonDto[]) => void;
 }
 
-export default function LessonOverview({lessons, updateCourse}: Readonly<LessonOverviewProps>) {
+export default function LessonOverview({updateCourse}: Readonly<LessonOverviewProps>) {
+    const {course} = useCourse();
     const {isInstructor} = useAuth();
 
     const deleteLesson = (lessonId: string) => {
-        if (lessons) {
-            updateCourse("lessons", convertToLessonDtoList(lessons.filter(lesson => lesson.id !== lessonId)))
+        if (course) {
+            updateCourse("lessons", convertToLessonDtoList(course.lessons.filter(lesson => lesson.id !== lessonId)))
         }
     }
     return (
@@ -31,23 +32,21 @@ export default function LessonOverview({lessons, updateCourse}: Readonly<LessonO
                     variant={"outlined"}
                 >Create</Button>}
             <List>
-                {lessons?.filter(lesson => isInstructor ? lesson : lesson.whenPublic.valueOf() < Date.now()).toSorted((a, b) => a?.whenPublic.getTime() - b?.whenPublic.getTime()).toSorted((a, b) => a?.whenPublic.getTime() - b?.whenPublic.getTime()).map(lesson=> (
-                    <>
-                        <ListItem
-                            key={`lesson-${lesson.id}`}
-                            secondaryAction={isInstructor &&
-                                <ConfirmedDeleteIconButton toConfirmId={lesson.id} toConfirmName={lesson.title} toConfirmFunction={deleteLesson}/>}
-                            disablePadding
+                {course?.lessons?.filter(lesson => isInstructor ? lesson : lesson.whenPublic.valueOf() < Date.now()).toSorted((a, b) => a?.whenPublic.getTime() - b?.whenPublic.getTime()).toSorted((a, b) => a?.whenPublic.getTime() - b?.whenPublic.getTime()).map(lesson=> (
+                    <ListItem
+                        key={`lesson-${lesson.id}`}
+                        secondaryAction={isInstructor &&
+                            <ConfirmedDeleteIconButton toConfirmId={lesson.id} toConfirmName={lesson.title} toConfirmFunction={deleteLesson}/>}
+                        disablePadding
+                        divider
+                    >
+                        <ListItemButton
+                            component={Link}
+                            to={`${lesson.id}`}
                         >
-                            <ListItemButton
-                                component={Link}
-                                to={`${lesson.id}`}
-                            >
-                                <ListItemText primary={lesson.title} secondary={lesson.whenPublic.valueOf() > Date.now() && "Unpublished"}/>
-                            </ListItemButton>
-                        </ListItem>
-                        <Divider/>
-                    </>
+                            <ListItemText primary={lesson.title} secondary={lesson.whenPublic.valueOf() > Date.now() && "Unpublished"}/>
+                        </ListItemButton>
+                    </ListItem>
                 )) 
                 }
             </List>

--- a/frontend/src/pages/CourseDetails/Lesson/LessonPage.tsx
+++ b/frontend/src/pages/CourseDetails/Lesson/LessonPage.tsx
@@ -5,29 +5,30 @@ import EditableTextDetail from "../../../components/Shared/EditableTextDetail.ts
 import {convertToLessonDto, convertToLessonDtoList} from "../../../utils/convertToLessonDto.ts";
 import {useAuth} from "../../../hooks/useAuth.ts";
 import {Button} from "@mui/material";
+import {useCourse} from "../../../hooks/useCourse.ts";
 
 type LessonPageProps = {
-    lessons: Lesson[] | undefined,
     updateCourse: (updatedProperty: string, updatedValue: LessonDto[]) => void,
 }
 
-export default function LessonPage({lessons, updateCourse}: Readonly<LessonPageProps>) {
+export default function LessonPage({updateCourse}: Readonly<LessonPageProps>) {
     const [lesson, setLesson] = useState<LessonDto | undefined>();
     const {lessonId} = useParams();
+    const {course} = useCourse();
     const {isInstructor} = useAuth();
 
     useEffect(()=>{
-        if (lessons) {
-            const currentLesson : Lesson | undefined = lessons.find(lesson => lesson.id === lessonId);
+        if (course) {
+            const currentLesson : Lesson | undefined = course.lessons.find(lesson => lesson.id === lessonId);
             if (currentLesson) setLesson(convertToLessonDto(currentLesson));
         }
-    },[lessons, lessonId])
+    },[course, lessonId])
 
     const handleUpdate = (updatedProperty: string, updatedValue: string) => {
-        if (lesson && lessons) {
+        if (lesson && course) {
             const updatedLesson = {...lesson,[updatedProperty]: updatedValue};
             setLesson(updatedLesson);
-            updateCourse("lessons", convertToLessonDtoList(lessons)
+            updateCourse("lessons", convertToLessonDtoList(course.lessons)
                .map(lesson => lesson.id === lessonId ? updatedLesson : lesson));
         }
     }

--- a/frontend/src/pages/CourseDetails/Participant/ParticipantOverview.tsx
+++ b/frontend/src/pages/CourseDetails/Participant/ParticipantOverview.tsx
@@ -1,27 +1,27 @@
 import {Grid2} from "@mui/material";
 import EditableListDetail from "../../../components/Shared/EditableListDetail.tsx";
 import {Instructor, Student} from "../../../types/userTypes.ts";
+import {useCourse} from "../../../hooks/useCourse.ts";
 
 type ParticipantOverviewProps = {
-    currentStudents: string[],
-    currentInstructors: string[],
     students: Student[],
     instructors: Instructor[],
     updateCourse: (updatedProperty: string, updatedValue: string | string[]) => void,
 };
 
-export default function ParticipantOverview({currentStudents, currentInstructors, students, instructors, updateCourse}: Readonly<ParticipantOverviewProps>) {
+export default function ParticipantOverview({students, instructors, updateCourse}: Readonly<ParticipantOverviewProps>) {
+    const {course} = useCourse();
     return (
         <Grid2 container spacing={2}>
             <Grid2 size={12}>
                 <h3>Participants</h3>
             </Grid2>
             <Grid2 size={{xs:12, sm:6}}>
-                <EditableListDetail label={"Students"} name={"students"} initialValue={currentStudents}
+                <EditableListDetail label={"Students"} name={"students"} initialValue={course?.students || []}
                                     updateCourse={updateCourse} options={students}/>
             </Grid2>
             <Grid2 size={{xs: 12, sm: 6}}>
-                <EditableListDetail label={"Instructors"} name={"instructors"} initialValue={currentInstructors}
+                <EditableListDetail label={"Instructors"} name={"instructors"} initialValue={course?.instructors || []}
                                     updateCourse={updateCourse} options={instructors}/>
             </Grid2>
         </Grid2>


### PR DESCRIPTION
Goal: access selected course properties in all course sub pages

- added context to Outlet to CourseDetailsPage
- created custom hook and context type to access context in all subpages, e.g. lessons, assignments and participants