### PR TITLE
fix/fix-course-tabs-navigation

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -212,8 +212,8 @@ export default function App() {
                                     <Route path={"assignments/:assignmentId"} element={<AssignmentPage updateCourse={updateCourse}/>}/>
                                     <Route path={"assignments/:assignmentId/submission/:submissionId"} element={<SubmissionPage/>}/>
                                     <Route element={<ProtectedInstructorRoutes />}>
-                                        <Route path={"lessons/create"} element={<LessonCreator updateCourse={updateCourse}/>}/>
-                                        <Route path={"assignments/create"} element={<AssignmentCreator updateCourse={updateCourse} />}/>
+                                        <Route path={"lessons/create"} element={<LessonCreator updateCourse={updateCourse} course={currentCourse}/>}/>
+                                        <Route path={"assignments/create"} element={<AssignmentCreator updateCourse={updateCourse} course={currentCourse}/>}/>
                                     </Route>
                                 </Route>
                                 <Route element={<ProtectedInstructorRoutes/>}>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -205,7 +205,7 @@ export default function App() {
                                 <Route path={"/browse"} element={<BrowsePage courses={courses} deleteCourse={deleteCourse} updateUser={updateUser} updateCourse={updateCourse}/>}/>
                                 <Route path={"/account"} element={<UserAccountPage updateUser={updateUser} deleteUser={deleteUser}/>}/>
                                 <Route path={"/course/:courseId"} element={<CourseDetailsPage updateCourse={updateCourse} course={currentCourse} fetchCourse={fetchCourse} deleteCourse={deleteCourse} students={students} instructors={instructors} updateUser={updateUser}/>}>
-                                    <Route path={"participants"} element={<ParticipantOverview currentStudents={currentCourse?.students || []} currentInstructors={currentCourse?.instructors || []} students={students} instructors={instructors} updateCourse={updateCourse}/>}/>
+                                    <Route index element={<ParticipantOverview currentStudents={currentCourse?.students || []} currentInstructors={currentCourse?.instructors || []} students={students} instructors={instructors} updateCourse={updateCourse}/>}/>
                                     <Route path={"lessons"} element={<LessonOverview lessons={currentCourse?.lessons} updateCourse={updateCourse}/>}/>
                                     <Route path={"lessons/:lessonId"} element={<LessonPage lessons={currentCourse?.lessons} updateCourse={updateCourse}/>}/>
                                     <Route path={"assignments"} element={<AssignmentOverview assignments={currentCourse?.assignments} updateCourse={updateCourse}/>}/>

--- a/frontend/src/components/Course/CourseTabs.tsx
+++ b/frontend/src/components/Course/CourseTabs.tsx
@@ -1,26 +1,30 @@
 import {Tab, Tabs} from "@mui/material";
-import {Link, matchPath, useLocation} from "react-router-dom";
+import {Link} from "react-router-dom";
 import {coursePages} from "../../utils/constants.ts";
+import {useState} from "react";
 
 export default function CourseTabs() {
-    const routeMatch = useRouteMatch(['/course/:courseId/participants', '/course/:courseId/lessons', '/course/:courseId/assignments']);
-    const currentTab = routeMatch ?? 0;
-
-    function useRouteMatch(patterns: readonly string[]) {
-        const { pathname } = useLocation();
-        for (let i = 0; i < patterns.length; i += 1) {
-            const pattern = patterns[i];
-            const possibleMatch = matchPath(pattern, pathname);
-            if (possibleMatch !== null) {
-                return i;
-            }
-        }
-        return null;
-    }
+    const [currentTab, setCurrentTab] = useState<number>(0);
 
     return (
-        <Tabs value={currentTab} component={"nav"}>
-            {coursePages.map(page => <Tab key={page.url} icon={<page.icon/>} iconPosition={"start"} label={page.title} to={page.url} component={Link}/>)}
+        <Tabs
+            value={currentTab}
+            component={"nav"}
+            onChange={(_event, newValue) => {
+            setCurrentTab(newValue);
+            }}
+            variant={'fullWidth'}
+        >
+            {coursePages.map(page =>
+                <Tab
+                    key={page.url}
+                    icon={<page.icon/>}
+                    iconPosition={"start"}
+                    label={page.title}
+                    component={Link}
+                    to={page.url}
+                    disableRipple
+                />)}
         </Tabs>
     );
 }

--- a/frontend/src/pages/CourseDetails/Assignment/AssignmentCreator.tsx
+++ b/frontend/src/pages/CourseDetails/Assignment/AssignmentCreator.tsx
@@ -1,16 +1,15 @@
-import { AssignmentDto} from "../../../types/courseTypes.ts";
+import {AssignmentDto, Course} from "../../../types/courseTypes.ts";
 import {ChangeEvent, FormEvent, useState} from "react";
 import {Link, useNavigate} from "react-router-dom";
 import {convertToAssignmentDtoList} from "../../../utils/convertToAssignmentDto.ts";
 import {Button, Grid2, TextField} from "@mui/material";
-import {useCourse} from "../../../hooks/useCourse.ts";
 
 type AssignmentCreatorProps = {
-    updateCourse: (updatedProperty: string, updatedValue: AssignmentDto[]) => void
+    updateCourse: (updatedProperty: string, updatedValue: AssignmentDto[]) => void,
+    course: Course | undefined
 }
 
-export default function AssignmentCreator({ updateCourse}: Readonly<AssignmentCreatorProps>) {
-    const {course} = useCourse();
+export default function AssignmentCreator({course, updateCourse}: Readonly<AssignmentCreatorProps>) {
     const [assignment, setAssignment] = useState<AssignmentDto>({
         id: "",
         title: "",

--- a/frontend/src/pages/CourseDetails/CourseDetailsPage.tsx
+++ b/frontend/src/pages/CourseDetails/CourseDetailsPage.tsx
@@ -6,7 +6,7 @@ import {Instructor, Student} from "../../types/userTypes.ts";
 import {useAuth} from "../../hooks/useAuth.ts";
 import CourseActions from "../../components/Course/CourseActions.tsx";
 import {
-    Breadcrumbs,
+    Breadcrumbs, Container,
     Grid2, ListItem, ListItemText, Paper,
     Typography, useMediaQuery, useTheme
 } from "@mui/material";
@@ -44,7 +44,6 @@ export default function CourseDetailsPage({updateCourse, course, fetchCourse, de
                         <Typography>{course?.title}</Typography>
                     </Breadcrumbs>
                     <ListItem
-                        sx={{bgcolor:'background.paper'}}
                         secondaryAction={<CourseActions course={course} deleteCourse={deleteCourse} updateUser={updateUser} updateCourse={updateCourse}/>}
                         disablePadding
                         component={"div"}
@@ -72,9 +71,13 @@ export default function CourseDetailsPage({updateCourse, course, fetchCourse, de
                             </Grid2>
                         </Grid2>
                     </Paper>
-                    {isMobile ? <CourseTabsMobile/> :
-                    <CourseTabs/>}
-                    <Outlet/>
+                    <Container disableGutters >
+                        {isMobile ? <CourseTabsMobile/> :
+                            <CourseTabs/>}
+                        <Paper sx={{p:'20px', pb: '40px'}} component={'section'} square={false}>
+                            <Outlet/>
+                        </Paper>
+                    </Container>
                 </div>
             :
             <p>No course found.</p>

--- a/frontend/src/pages/CourseDetails/Lesson/LessonCreator.tsx
+++ b/frontend/src/pages/CourseDetails/Lesson/LessonCreator.tsx
@@ -1,16 +1,15 @@
-import {LessonDto} from "../../../types/courseTypes.ts";
+import {Course, LessonDto} from "../../../types/courseTypes.ts";
 import {ChangeEvent, FormEvent, useState} from "react";
 import {Link, useNavigate} from "react-router-dom";
 import {convertToLessonDtoList} from "../../../utils/convertToLessonDto.ts";
 import {Button, Grid2, TextField} from "@mui/material";
-import {useCourse} from "../../../hooks/useCourse.ts";
 
 type LessonCreatorProps = {
-    updateCourse: (updatedProperty: string, updatedValue: LessonDto[]) => void
+    updateCourse: (updatedProperty: string, updatedValue: LessonDto[]) => void,
+    course: Course | undefined
 }
 
-export default function LessonCreator({updateCourse}:Readonly<LessonCreatorProps>) {
-    const {course} = useCourse();
+export default function LessonCreator({course, updateCourse}:Readonly<LessonCreatorProps>) {
     const [lesson, setLesson] = useState<LessonDto>({
         id:"",
         title:"",

--- a/frontend/src/styles/themeOptions.ts
+++ b/frontend/src/styles/themeOptions.ts
@@ -30,12 +30,14 @@ export const themeOptions: ThemeOptions = {
                 }
             }
         },
-        MuiListItemSecondaryAction: {
+        MuiTab: {
             styleOverrides: {
                 root: {
-
+                    '&.Mui-focusVisible': {
+                        backgroundColor: 'rgba(76,131,245,0.2)',
+                    }
                 }
-            }
+        }
         }
     }
 };

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -18,7 +18,7 @@ export const pages : {title: string, url: string}[] = [
 export const coursePages : {title: string, url: string, icon:  OverridableComponent<SvgIconTypeMap> & {         muiName: string     }}[] = [
     {
         title: "Participants",
-        url: "participants",
+        url: "",
         icon: PeopleIcon
     },
     {


### PR DESCRIPTION
Issues:
- when loading the Course details page, no subpage is automatically shown despite the tab being selected
- the tab resets when clicking on a subpage of the tab subpage
- related to prev PR: when creating a new assignment or lesson, the component does not have acces to the course context because it is in further subrouting

Solutions:
- Simplify tab index to stay on tab
- Give participants route index property rather than specific path, so that it is automatically shown when on CourseDetails Route
- give course props directly to AssignmentCreator and LessonCreator

Adjusted Course Tabs Styling